### PR TITLE
add auto_reply_100_continue config option

### DIFF
--- a/src/http/headers.rs
+++ b/src/http/headers.rs
@@ -8,6 +8,7 @@ pub struct Headers<'a> {
     content_length: Option<u64>,
     chunked: bool,
     connection_close: bool,
+    expect_100_continue: bool,
     print_date: bool,
 }
 
@@ -40,6 +41,7 @@ impl<'a> Headers<'a> {
             content_length: None,
             chunked: false,
             connection_close: false,
+            expect_100_continue: false,
             print_date: true,
         }
     }
@@ -50,6 +52,7 @@ impl<'a> Headers<'a> {
             content_length: None,
             chunked: false,
             connection_close: false,
+            expect_100_continue: false,
             print_date: false,
         }
     }
@@ -96,6 +99,9 @@ impl<'a> Headers<'a> {
                     break;
                 }
             }
+        } else if name.eq_ignore_ascii_case("expect") && value.eq_ignore_ascii_case(b"100-continue")
+        {
+            self.expect_100_continue = true;
         }
 
         self.headers.push((name, value));
@@ -212,9 +218,7 @@ impl<'a> Headers<'a> {
     }
 
     pub fn is_100_continue(&self) -> bool {
-        self.get("expect")
-            .map(|val| val.eq_ignore_ascii_case(b"100-continue"))
-            .unwrap_or(false)
+        self.expect_100_continue
     }
 }
 

--- a/src/server/builder.rs
+++ b/src/server/builder.rs
@@ -22,6 +22,7 @@ pub struct ServerBuilder {
     thread_count: usize,
     max_request_head_size: usize,
     epoll_queue_max_events: usize,
+    auto_reply_100_continue: bool,
 }
 
 impl ServerBuilder {
@@ -46,6 +47,7 @@ impl ServerBuilder {
             thread_count: get_default_thread_count(),
             max_request_head_size: DEFAULT_MAX_REQUEST_HEAD,
             epoll_queue_max_events: DEFAULT_EPOLL_QUEUE_MAXEVENTS,
+            auto_reply_100_continue: true,
         })
     }
 
@@ -59,6 +61,7 @@ impl ServerBuilder {
                 pre_routing_hook: self.pre_routing_hook,
                 connection_teardown_hook: self.connection_teardown_hook,
                 max_request_head: self.max_request_head_size,
+                auto_reply_100_continue: self.auto_reply_100_continue,
             }),
             epoll_queue_max_events: self.epoll_queue_max_events,
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -32,6 +32,7 @@ struct HandlerConfig {
     pre_routing_hook: Option<Box<PreRoutingHookFn>>,
     connection_teardown_hook: Option<Box<ConnectionTeardownHookFn>>,
     max_request_head: usize,
+    auto_reply_100_continue: bool,
 }
 
 pub struct Server {
@@ -345,6 +346,10 @@ fn handle_one_request<'s>(
     let matched_route = config
         .router
         .match_route(&request.method, request.uri.path());
+
+    if config.auto_reply_100_continue && request.headers.is_100_continue() {
+        response.send_100_continue()?;
+    }
 
     let body = BodyReader::from_request(&buf[request.buf_offset..], stream, &request.headers);
     let ctx = RequestContext {


### PR DESCRIPTION
Adds config option to automatically reply `HTTP/1.1 100 Continue` if request headers include `Expect: 100-continue`